### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-122457/DiscoveriesBattleshipGame/security/code-scanning/2](https://github.com/IGE-122457/DiscoveriesBattleshipGame/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token scopes are intentionally restricted.  
Best fix (without changing behavior): set minimal read-only access at the workflow root, which applies to all jobs unless overridden.

In `.github/workflows/pr-notification.yml`, insert:

- `permissions: {}` would disable all token permissions, but the safer broadly compatible minimal baseline is:
  - `permissions:`
    - `contents: read`

Since this workflow only prints a message, `contents: read` is sufficient and non-breaking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
