### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-122457/DiscoveriesBattleshipGame/security/code-scanning/1](https://github.com/IGE-122457/DiscoveriesBattleshipGame/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (right after `on` is a common location, before `jobs`) to define the minimum required `GITHUB_TOKEN` scope. For this workflow, `contents: read` is the best minimal setting and should not change existing functionality, since the workflow checks out code and pushes to Docker Hub using Docker credentials from secrets rather than GitHub package writes.

**File to change:** `.github/workflows/docker-publish.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed for YAML workflow permission configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
